### PR TITLE
Update teardown playbook to remove error when perform teardown

### DIFF
--- a/provisioner/teardown_lab.yml
+++ b/provisioner/teardown_lab.yml
@@ -12,7 +12,7 @@
 
   roles:
     - manage_ec2_instances
-    - { role: aws_workshop_login_page, when: create_login_page is defined }
+    - { role: aws_workshop_login_page, when: create_login_page is defined and create_login_page }
 
   post_tasks:
    - name: Remove workshop local files


### PR DESCRIPTION
You only need to run aws_workshop_login_page role when both create_login_page is defined AND create_login_page condition. Because create_login_page condition was missing, it did not skip this and causes error when performing teardown.